### PR TITLE
API取得で400エラーが出るのを修正

### DIFF
--- a/Yairc/API.pm
+++ b/Yairc/API.pm
@@ -25,9 +25,8 @@ sub get_log_data {
         push(@hash_list, $hash);
     }
 
-    my $json = JSON->new;
     return {
-        'data'          => $json->encode(\@hash_list),
+        'data'          => encode_json(\@hash_list),
         'content-type'  => 'application/json',
     };
 }


### PR DESCRIPTION
400エラーが出ちゃうのを修正しました
昨日の晩やってた時は取得できてたんですが今朝試したらなぜか400エラーになるようになってしまいました
(原因がよくわからない)

リクエストサンプル
https://gist.github.com/2440738

これからのAPI仕様がどうなるかわからないのでpull requestはいったんここで終わりにしておきます
