### PR TITLE
API::Search URLが含まれる発言のみを抽出するフィルターを追加

### DIFF
--- a/lib/Yairc/API/Search.pm
+++ b/lib/Yairc/API/Search.pm
@@ -47,18 +47,17 @@ sub _search_posts {
     my $posts = $self->data_storage->search_post( $where, $attr );
 
     # if文のネストを浅くしたい
-    if ( my $filter = $req->param('filter') ) {
-        if ( $filter eq 'url' ) {
-            my @filtered_posts = ();
-            foreach my$post( @$posts ) {
-                # regex comes from public/js/main.js 
-                if ($post->{ text } =~ m.https?://([\x21-\x7e]+).gi) {
-                    push(@filtered_posts, $post);
-                }
+    my $filter = $req->param('filter') || '';
+    if ( $filter eq 'url' ) {
+        my @filtered_posts = ();
+        foreach my$post( @$posts ) {
+            # regex comes from public/js/main.js 
+            if ($post->{ text } =~ m.https?://([\x21-\x7e]+).gi) {
+                push(@filtered_posts, $post);
             }
-
-            return \@filtered_posts;
         }
+
+        return \@filtered_posts;
     }
 
     return $posts;


### PR DESCRIPTION
個人的に欲しかった、URLの含まれる発言のみの抽出する機能を追加
/api に filter=url を送るとURLが含まれる発言のみを抽出します
/apiにリクエストを送れば使えるが、まだクライアントには組み込んでない

URLの抽出をどこに組み込めばいいのかわからなかったので、とりあえずAPI::Search->_search_posts()内に実装

yairc_api_request_sample.pl 更新
https://gist.github.com/2440738
