### PR TITLE
Stop annoying warnings of Net-Twitter-Lite-0.11001.

### DIFF
--- a/lib/Yairc/Login/Twitter.pm
+++ b/lib/Yairc/Login/Twitter.pm
@@ -19,6 +19,7 @@ sub build_psgi_endpoint {
     my $nt = Net::Twitter::Lite->new(
         consumer_key    => $opt->{ consumer_key },
         consumer_secret => $opt->{ consumer_secret },
+        legacy_lists_api => 0,
     );
 
     # Carp::croak("Invalid login endpoint root.") unless $endpoint_root =~ m{^[-./\w]*$};


### PR DESCRIPTION
I run `make test`, then I get following warnings;

```
  For backwards compatibility Net::Twitter::Lite uses the deprecated Lists API
  endpoints and semantics. This default will be changed in a future version.
  Please update your code to use the new lists semantics and pass
  (legacy_lists_api => 0) to new.

  You can disable this warning, and keep backwards compatibility by passing
  (legacy_lists_api => 1) to new. Be warned, however, that support for the
  legacy endpoints will be removed in a future version and the default will
  change to (legacy_lists_api => 0). at /private/tmp/yairc/lib/Yairc/Login/Twitter
  .pm line 22
```

I don't like this change of Net-Twitter-Lite-0.11001 :(
