### PR TITLE
縦幅が異常に長いのを画面合わせの高さに修正

### DIFF
--- a/public/stylesheets/iphone.css
+++ b/public/stylesheets/iphone.css
@@ -7,7 +7,7 @@ margin:0px;
 #nickname, #connecting, #loading {
   position: absolute;
   width: 100%;
-  height: 2000px;
+  height: 100%;
   z-index: 100;
   left: 0;
   top: 0;

--- a/public/stylesheets/pc.css
+++ b/public/stylesheets/pc.css
@@ -10,7 +10,7 @@ a{
 #nickname, #connecting, #loading {
   position: absolute;
   width: 100%;
-  height: 2000px;
+  height: 100%;
   z-index: 100;
   left: 0;
   top: 0;


### PR DESCRIPTION
手元にあるiOS6のiPod touchとWindows版Chromeで確認している限りでは、余分な縦スクロールは消えました

現在のmasterは縦幅の指定が2000pxになっていますが、100%ではない理由が何かあったりするんでしょうか
- https://github.com/uzulla/yancha/blob/master/public/stylesheets/pc.css#L13
- https://github.com/uzulla/yancha/blob/master/public/stylesheets/iphone.css#L10
