### PR TITLE
PostAPIのタグ挿入処理の改善

### DIFF
--- a/lib/Yancha/API/Post.pm
+++ b/lib/Yancha/API/Post.pm
@@ -21,9 +21,7 @@ sub run {
     return $self->response({}, 400) unless $text;
 
     my @tags = $self->sys->extract_tags_from_text( $text );
-    unless (@tags) {
-        @tags = qw(PUBLIC);
-    }
+    $self->sys->add_default_tag( \@tags, \$text ) unless @tags;
 
     my $post = $data_storage->make_post({
         text => $text,
@@ -38,6 +36,10 @@ sub run {
     $self->sys->call_hook( 'user_message', undef, \$text, $ctx );
 
     $self->sys->call_hook( 'before_send_post', undef, $post, $ctx );
+
+    my $tmp = $post->{text};
+    $self->sys->add_default_tag( $post->{tags}, \$tmp) unless @{$post->{tags}};
+    $post->{text} = $tmp;
 
     $data_storage->add_post($post);
 

--- a/t/836_search_api_rss_default_order_desc.t
+++ b/t/836_search_api_rss_default_order_desc.t
@@ -49,9 +49,9 @@ test_pocketio $server => sub {
     };
 
     my @posts = (
-        "Hello World. #public",
-        "Hello world.",
-        "Hello Perl.",
+        "Hello World. #PUBLIC",
+        "Hello world. #PUBLIC",
+        "Hello Perl. #PUBLIC",
     );
     
     for my$text( @posts ) {


### PR DESCRIPTION
- PUBLICタグのみの時に#PUBLICタグを挿入
- プラグインによりタグが消された時に詰まるバグをkaisyou

修正したテストの主役はソートなのでタグ周りのテストを気にする必要はなし
