### PR TITLE
外部クライアントでもTwitterログインが出来るようになったよー

### DIFF
--- a/lib/Yancha/Auth/Simple.pm
+++ b/lib/Yancha/Auth/Simple.pm
@@ -47,8 +47,9 @@ sub build_psgi_endpoint {
             } );
 
             # TODO: ここから下まとめる
-            return $self->response_token_only($user)->finalize
-                                    if $req->parameters->{ token_only };
+            if ( $req->parameters->{ token_only } ) {
+                return $self->response_token_only($user, $req->parameters->{ callback_url } )->finalize;
+            }
 
             $session->set( 'token', $user->{ token } );
 

--- a/t/302_login_simple_callback.t
+++ b/t/302_login_simple_callback.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use PocketIO::Test;
+use t::Utils;
+use Yancha::Client;
+use HTTP::Request::Common qw/GET/;
+use LWP::UserAgent;
+
+BEGIN {
+    use Test::More;
+    plan skip_all => 'PocketIO::Client::IO are required to run this test'
+      unless eval { require PocketIO::Client::IO; 1 };
+}
+
+my $testdb = t::Utils->setup_testdb( schema => './db/init.sql' );
+my $config = {
+    database    => { connect_info => [ $testdb->dsn ] },
+    server_info => {
+        api_endpoint => {
+            '/api/user' => [ 'Yancha::API::User', {}, 'For testing' ],
+        }
+    },
+};
+my $server = t::Utils->server_with_dbi( config => $config );
+
+test_pocketio $server, sub {
+    my ( $port ) = shift;
+
+    my $callback_url = "http://simple-login.test/callback";
+    my $ua       = LWP::UserAgent->new;
+    my $req      = GET "http://localhost:$port/login?callback_url=$callback_url&nick=tester&token_only=1";
+    my $response = $ua->simple_request($req);
+
+    ok( $response->is_redirect );
+
+    my $location = $response->header( 'Location' );
+    ok( $location =~ m/^$callback_url\?token=[a-zA-Z0-9]+$/ );
+
+};
+
+
+done_testing;
+
+


### PR DESCRIPTION
ログインAPIに _token_only=1_ と _callback_url=$callback_url_ パラメータをつけると、GETパラメータに _token_ のついたURLへコールバックします

これにより、ログイン時にURIスキーマを利用したスマートフォンアプリへのコールバックも可能になります

```
# 例
GET: http://yancha.hachiojipm.org/login/twitter/start?token_only=1&callback_url=yancha%3a%2f%2flogin%2fcallback
```
