### PR TITLE
nicknamesイベントでプロフィール情報を取ってこれるようにした(サーバー側のみ

### DIFF
--- a/lib/Yancha/Core.pm
+++ b/lib/Yancha/Core.pm
@@ -281,7 +281,17 @@ sub _send_lastlog_by_tag_lastusec {
 
 sub _get_uniq_and_anon_nicknames {
     my ( $users ) = @_;
-    return { map { $_->{ nickname } => $_->{ nickname } } values %$users };
+    my @extract_fields = qw/nickname profile_image_url profile_url/;
+
+    my $unique_users = {};
+    for my$user ( values %$users ) {
+        my $unique_user = {};
+        for my$field ( @extract_fields ) {
+            $unique_user->{$field} = $user->{$field};
+        }
+        $unique_users->{ $user->{nickname} } = $unique_user;
+    }
+    return $unique_users;
 }
 
 sub _nickname_and_token {

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -47,7 +47,7 @@ socket.on('nicknames', function (nicknames) {
   $('#nicknames').empty();
   var join_num = 0;
   for (var i in nicknames) {
-    $('#nicknames').append($('<b>').text(nicknames[i]));
+    $('#nicknames').append($('<b>').text(nicknames[i].nickname)).append('</b>');
     join_num += 1;
   }
   $('#join_num').text(join_num);

--- a/t/300_login_simple.t
+++ b/t/300_login_simple.t
@@ -25,8 +25,11 @@ my $client = sub {
         $cv->send;
     } );
 
+    my $nickname = 'test_client';
+    my $profile_image_url = 'http://pyazo.hachiojipm.org/image/my_profile_image_url';
     ok( $client->login(
-            "http://localhost:$port/", => 'login', { nick => 'test_client' }
+            "http://localhost:$port/", => 'login',
+                { nick => $nickname, profile_image_url => $profile_image_url }
       ), 'login' );
     ok( $client->connect, 'connect' );
 
@@ -34,7 +37,8 @@ my $client = sub {
         my ( $self, $socket ) = @_;
 
         $socket->on('nicknames', sub {
-            is( $_[1]->{ test_client }, 'test_client', 'token login' );
+            is( $_[1]->{ $nickname }->{ nickname }, $nickname, 'compared nickname' );
+            is( $_[1]->{ $nickname }->{ profile_image_url }, $profile_image_url, 'compared profile image url' );
             $cv->send;
         });
 


### PR DESCRIPTION
uzulla/yancha内のクライアントに組み込むのはデザイン的にややこしいので諦めました

以下のようにユーザ一覧にアイコンを表示するのをスムーズに実装するための対応

![screenshot_2013-12-01-18-49-44](https://f.cloud.github.com/assets/381483/1650194/349ee6e0-5a71-11e3-9b7d-cf15f28de9e3.png)
