### PR TITLE
Chrome向けNotify対応

### DIFF
--- a/static/js/main_pc.js
+++ b/static/js/main_pc.js
@@ -7,7 +7,7 @@ hook.addHook('onUserMessage', function(hash){
     $.jwNotify({
       image : hash.profile_image_url,
       title: hash.nickname,
-      body: hash.text,
+      body: " " + hash.text,
       timeout: 10000
     });
   }


### PR DESCRIPTION
ChromeのNotifyが、1文字目が2バイト文字だと内容が表示されないバグが有り、
それに対する措置。
残念なことに、ローカル環境ではこのバグが再現しなかったので、
これで直るかどうかはわからない。
